### PR TITLE
Require drush-node instead of drush.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a simple node.js wrapper for running [drush](https://github.com/drush-op
 To use:
 
 ```javascript
-var drush = require('drush');
+var drush = require('drush-node');
 
 drush.init().then(
   function () {


### PR DESCRIPTION
Currently the README states that `drush` should be required, which doesn't require `drush-node`. This updates the documentations so that it requires the correct npm module.
